### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/R/gp_mle.R
+++ b/R/gp_mle.R
@@ -9,7 +9,7 @@ gp_mle <- function(gp_data) {
   #
   # Grimshaw, S. D. (1993) Computing Maximum Likelihood Estimates
   #   for the Generalized Pareto Distribution.  Technometrics, 35(2), 185-191.
-  #   and Computing (1991) 1, 129-133. http://dx.doi.org/10.1007/BF01889987.
+  #   and Computing (1991) 1, 129-133. https://doi.org/10.1007/BF01889987.
   #
   # Args:
   #   gp_data : A numeric vector containing positive values, assumed to be a

--- a/R/ithresh.R
+++ b/R/ithresh.R
@@ -218,17 +218,17 @@
 #' @references Northrop, P.J. and Attalides, N. (2016) Posterior propriety in
 #'   Bayesian extreme value analyses using reference priors
 #'   \emph{Statistica Sinica}, \strong{26}(2), 721--743
-#'   \url{http://dx.doi.org/10.5705/ss.2014.034}.
+#'   \url{https://doi.org/10.5705/ss.2014.034}.
 #' @references Northrop, P. J., Attalides, N. and Jonathan, P. (2017)
 #'   Cross-validatory extreme value threshold selection and uncertainty
 #'   with application to ocean storm severity.
 #'   \emph{Journal of the Royal Statistical Society Series C: Applied
 #'   Statistics}, \strong{66}(1), 93-120.
-#'   \url{http://dx.doi.org/10.1111/rssc.12159}
+#'   \url{https://doi.org/10.1111/rssc.12159}
 #' @references Jonathan, P. and Ewans, K. (2013) Statistical modelling
 #'   of extreme ocean environments for marine design : a review.
 #'   \emph{Ocean Engineering}, \strong{62}, 91-109.
-#'   \url{http://dx.doi.org/10.1016/j.oceaneng.2013.01.004}
+#'   \url{https://doi.org/10.1016/j.oceaneng.2013.01.004}
 #' @export
 ithresh <- function(data, u_vec, ..., n_v = 1, npy = NULL, use_rcpp = TRUE) {
   # Store npy (if it has been supplied)

--- a/R/parameter_stability.R
+++ b/R/parameter_stability.R
@@ -68,7 +68,7 @@
 #'   based on leave-one-out cross-validation.
 #' @references Coles, S. G. (2001) \emph{An Introduction to Statistical
 #'   Modeling of Extreme Values}, Springer-Verlag, London.
-#'   \url{http://dx.doi.org/10.1007/978-1-4471-3675-0_3}
+#'   \url{https://doi.org/10.1007/978-1-4471-3675-0_3}
 #' @seealso \code{\link{plot.stability}} for the S3 \code{plot} method for
 #'   objects of class \code{stability}.
 #' @seealso \code{\link[stats]{quantile}}.

--- a/R/predictive.R
+++ b/R/predictive.R
@@ -156,7 +156,7 @@
 #'   with application to ocean storm severity.
 #'   \emph{Journal of the Royal Statistical Society Series C: Applied
 #'   Statistics}, \strong{66}(1), 93-120.
-#'   \url{http://dx.doi.org/10.1111/rssc.12159}
+#'   \url{https://doi.org/10.1111/rssc.12159}
 #' @export
 predict.ithresh <- function(object, npy = NULL, n_years = 100,
                             which_u = c("best", "all"), which_v = 1L,

--- a/R/threshr.R
+++ b/R/threshr.R
@@ -23,7 +23,7 @@
 #'   with application to ocean storm severity.
 #'   \emph{Journal of the Royal Statistical Society Series C: Applied
 #'   Statistics}, \strong{66}(1), 93-120.
-#'   \url{http://dx.doi.org/10.1111/rssc.12159}
+#'   \url{https://doi.org/10.1111/rssc.12159}
 #'
 #' @seealso The packages \code{\link[revdbayes]{revdbayes}} and
 #'   \code{\link[rust]{rust}}.

--- a/man/ithresh.Rd
+++ b/man/ithresh.Rd
@@ -220,19 +220,19 @@ gom_cv <- ithresh(data = gom, u_vec = u_vec_gom, n_v = 2, prior = prior_ptr,
 Northrop, P.J. and Attalides, N. (2016) Posterior propriety in
   Bayesian extreme value analyses using reference priors
   \emph{Statistica Sinica}, \strong{26}(2), 721--743
-  \url{http://dx.doi.org/10.5705/ss.2014.034}.
+  \url{https://doi.org/10.5705/ss.2014.034}.
 
 Northrop, P. J., Attalides, N. and Jonathan, P. (2017)
   Cross-validatory extreme value threshold selection and uncertainty
   with application to ocean storm severity.
   \emph{Journal of the Royal Statistical Society Series C: Applied
   Statistics}, \strong{66}(1), 93-120.
-  \url{http://dx.doi.org/10.1111/rssc.12159}
+  \url{https://doi.org/10.1111/rssc.12159}
 
 Jonathan, P. and Ewans, K. (2013) Statistical modelling
   of extreme ocean environments for marine design : a review.
   \emph{Ocean Engineering}, \strong{62}, 91-109.
-  \url{http://dx.doi.org/10.1016/j.oceaneng.2013.01.004}
+  \url{https://doi.org/10.1016/j.oceaneng.2013.01.004}
 }
 \seealso{
 \code{\link{plot.ithresh}} for the S3 plot method for objects of

--- a/man/predict.ithresh.Rd
+++ b/man/predict.ithresh.Rd
@@ -175,7 +175,7 @@ Northrop, P. J., Attalides, N. and Jonathan, P. (2017)
   with application to ocean storm severity.
   \emph{Journal of the Royal Statistical Society Series C: Applied
   Statistics}, \strong{66}(1), 93-120.
-  \url{http://dx.doi.org/10.1111/rssc.12159}
+  \url{https://doi.org/10.1111/rssc.12159}
 }
 \seealso{
 \code{\link{ithresh}} for threshold selection in the i.i.d. case

--- a/man/stability.Rd
+++ b/man/stability.Rd
@@ -95,7 +95,7 @@ plot(gom_stab)
 \references{
 Coles, S. G. (2001) \emph{An Introduction to Statistical
   Modeling of Extreme Values}, Springer-Verlag, London.
-  \url{http://dx.doi.org/10.1007/978-1-4471-3675-0_3}
+  \url{https://doi.org/10.1007/978-1-4471-3675-0_3}
 }
 \seealso{
 \code{\link{ithresh}} for threshold selection in the i.i.d. case

--- a/man/threshr.Rd
+++ b/man/threshr.Rd
@@ -32,7 +32,7 @@ Northrop, P. J., Attalides, N. and Jonathan, P. (2017)
   with application to ocean storm severity.
   \emph{Journal of the Royal Statistical Society Series C: Applied
   Statistics}, \strong{66}(1), 93-120.
-  \url{http://dx.doi.org/10.1111/rssc.12159}
+  \url{https://doi.org/10.1111/rssc.12159}
 }
 \seealso{
 The packages \code{\link[revdbayes]{revdbayes}} and

--- a/vignettes/threshr.bib
+++ b/vignettes/threshr.bib
@@ -8,7 +8,7 @@ volume="26",
 number="2",
 pages="721--743",
 doi="10.5705/ss.2014.034",
-url="http://dx.doi.org/10.5705/ss.2014.034"
+url="https://doi.org/10.5705/ss.2014.034"
 }
 
 @article {NAJ2017,
@@ -18,7 +18,7 @@ journal = {Journal of the Royal Statistical Society: Series C (Applied Statistic
 volume = {66},
 number = {1},
 issn = {1467-9876},
-url = {http://dx.doi.org/10.1111/rssc.12159},
+url = {https://doi.org/10.1111/rssc.12159},
 doi = {10.1111/rssc.12159},
 pages = {93--120},
 keywords = {Cross-validation, Extreme value theory, Generalized Pareto distribution, Predictive inference, Threshold},
@@ -33,7 +33,7 @@ year = {2017},
     pages="257--280",
     year=2016,publisher="Chapman and Hall",address="London",
     doi = "10.1201/b19721-14",
-    url = {http://dx.doi.org/10.1201/b19721-14},
+    url = {https://doi.org/10.1201/b19721-14},
     note=""}
 
 @Manual{evdbayes,
@@ -79,5 +79,5 @@ Analysis},
     title="Statistical modelling of extreme ocean environments for marine design : a review",
     year=2013,journal="Ocean Engineering",
     volume="62",number="",pages="91--109",
-    url = {http://dx.doi.org/10.1016/j.oceaneng.2013.01.004},
+    url = {https://doi.org/10.1016/j.oceaneng.2013.01.004},
     note=""}


### PR DESCRIPTION
Hello :-)

The DOI Foundation [started recommending a new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). While their URL change may be a bit ironic, it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old `dx` subdomain is being redirected. So, there is no urgency here.

However, for consistency, this PRs suggests to update all static DOI links accordingly.

Cheers!